### PR TITLE
Add daily random practice mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+dist/

--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState, useCallback, useEffect } from 'react';
-import { GameState } from './types';
+import { GameState, Level } from './types';
 import { LEVELS } from './constants';
 import GameScreen from './components/GameScreen';
 import StartScreen from './components/StartScreen';
@@ -10,31 +10,41 @@ import LevelSelectionScreen from './components/LevelSelectionScreen';
 const App: React.FC = () => {
   const [gameState, setGameState] = useState<GameState>(GameState.Start);
   const [currentLevelIndex, setCurrentLevelIndex] = useState(0);
+  const [customLevel, setCustomLevel] = useState<Level | null>(null);
   const [score, setScore] = useState(0);
 
   const goToLevelSelection = useCallback(() => {
+    setCustomLevel(null);
     setGameState(GameState.LevelSelection);
   }, []);
 
-  const selectLevelAndStart = useCallback((levelIndex: number) => {
-    setCurrentLevelIndex(levelIndex);
+  const selectLevelAndStart = useCallback((level: Level, index?: number) => {
+    if (typeof index === 'number') {
+      setCurrentLevelIndex(index);
+      setCustomLevel(null);
+    } else {
+      setCustomLevel(level);
+    }
     setScore(0);
     setGameState(GameState.Playing);
   }, []);
   
   const goToStart = useCallback(() => {
+    setCustomLevel(null);
     setGameState(GameState.Start);
   }, []);
 
   const handleLevelComplete = useCallback((levelScore: number) => {
     setScore(prev => prev + levelScore);
-    if (currentLevelIndex < LEVELS.length - 1) {
+    if (customLevel) {
+      setGameState(GameState.GameEnd);
+    } else if (currentLevelIndex < LEVELS.length - 1) {
       setCurrentLevelIndex(prev => prev + 1);
       setGameState(GameState.LevelComplete);
     } else {
       setGameState(GameState.GameEnd);
     }
-  }, [currentLevelIndex]);
+  }, [currentLevelIndex, customLevel]);
 
   const nextLevel = useCallback(() => {
     setGameState(GameState.Playing);
@@ -69,8 +79,8 @@ const App: React.FC = () => {
       case GameState.Playing:
         return (
           <GameScreen
-            level={LEVELS[currentLevelIndex]}
-            levelNumber={currentLevelIndex + 1}
+            level={customLevel ?? LEVELS[currentLevelIndex]}
+            levelNumber={customLevel ? 0 : currentLevelIndex + 1}
             onLevelComplete={handleLevelComplete}
           />
         );

--- a/components/CharacterInput.tsx
+++ b/components/CharacterInput.tsx
@@ -78,7 +78,7 @@ const CharacterInput: React.FC<CharacterInputProps> = ({
   }, [virtualEvent, isActive, processInput]);
 
   const isPracticeMode = levelType === LevelType.SingleBopomofo || levelType === LevelType.Syllable;
-  const isLongPhrase = levelType === LevelType.Word && targetChar.length > 5;
+  const isLongPhrase = (levelType === LevelType.Word || levelType === LevelType.Random) && targetChar.length > 5;
 
   const wrapperClasses = `
     relative flex flex-col items-center justify-center transition-all duration-300

--- a/components/GameScreen.tsx
+++ b/components/GameScreen.tsx
@@ -40,7 +40,7 @@ const GameScreen: React.FC<GameScreenProps> = ({ level, levelNumber, onLevelComp
       setPhase('introduction');
       setIntroductionIndex(0);
       speak(units[0]);
-    } else if (level.type === LevelType.Syllable || level.type === LevelType.Word) {
+    } else if (level.type === LevelType.Syllable || level.type === LevelType.Word || level.type === LevelType.Random) {
       units = level.content as string[];
       setPhase('practice');
     }
@@ -165,7 +165,7 @@ const GameScreen: React.FC<GameScreenProps> = ({ level, levelNumber, onLevelComp
       <div className="flex justify-between items-center mb-6 p-4 bg-slate-800/50 rounded-lg">
         <div>
           <h2 className="text-2xl font-bold text-sky-300">{level.title}</h2>
-          <p className="text-slate-400">第 {levelNumber} 關</p>
+          {level.type !== LevelType.Random && <p className="text-slate-400">第 {levelNumber} 關</p>}
           {level.description && <p className="text-sm text-slate-300 mt-1">{level.description}</p>}
         </div>
         <div className="text-right">

--- a/components/LevelSelectionScreen.tsx
+++ b/components/LevelSelectionScreen.tsx
@@ -1,26 +1,29 @@
 import React from 'react';
-import { LEVELS } from '../constants';
+import { LEVELS, generateRandomLevel } from '../constants';
 import { Level } from '../types';
 
 interface LevelSelectionScreenProps {
-  onSelectLevel: (levelIndex: number) => void;
+  onSelectLevel: (level: Level, index?: number) => void;
   onBack: () => void;
 }
 
-const LevelCard: React.FC<{ level: Level, index: number, onSelect: (index: number) => void }> = ({ level, index, onSelect }) => {
-    return (
-        <div
-            onClick={() => onSelect(index)}
-            className="bg-slate-800/70 p-4 rounded-lg shadow-lg cursor-pointer transition-all duration-300 hover:bg-sky-500/30 hover:shadow-sky-500/20 hover:scale-105"
-        >
-            <p className="text-sm text-sky-300 font-semibold">第 {index + 1} 課</p>
-            <h3 className="text-xl font-bold text-white mt-1 truncate">{level.title}</h3>
-            {level.description && <p className="text-slate-400 text-sm mt-2 h-10 overflow-hidden">{level.description}</p>}
-        </div>
-    )
-}
+const LevelCard: React.FC<{ level: Level; index: number; onSelect: (level: Level, index: number) => void }> = ({ level, index, onSelect }) => (
+  <div
+    onClick={() => onSelect(level, index)}
+    className="bg-slate-800/70 p-4 rounded-lg shadow-lg cursor-pointer transition-all duration-300 hover:bg-sky-500/30 hover:shadow-sky-500/20 hover:scale-105"
+  >
+    <p className="text-sm text-sky-300 font-semibold">第 {index + 1} 課</p>
+    <h3 className="text-xl font-bold text-white mt-1 truncate">{level.title}</h3>
+    {level.description && <p className="text-slate-400 text-sm mt-2 h-10 overflow-hidden">{level.description}</p>}
+  </div>
+);
 
 const LevelSelectionScreen: React.FC<LevelSelectionScreenProps> = ({ onSelectLevel, onBack }) => {
+  const handleRandom = () => {
+    const randomLevel = generateRandomLevel();
+    onSelectLevel(randomLevel);
+  };
+
   return (
     <div className="flex flex-col h-full w-full">
       <h2 className="text-4xl font-bold text-center text-yellow-300 mb-6">選擇關卡</h2>
@@ -29,7 +32,13 @@ const LevelSelectionScreen: React.FC<LevelSelectionScreenProps> = ({ onSelectLev
           <LevelCard key={index} level={level} index={index} onSelect={onSelectLevel} />
         ))}
       </div>
-      <div className="mt-6 text-center">
+      <div className="mt-6 text-center space-x-4">
+        <button
+          onClick={handleRandom}
+          className="px-8 py-3 bg-sky-600 text-white font-bold rounded-lg shadow-lg hover:bg-sky-700 transition-transform transform hover:scale-105 focus:outline-none focus:ring-4 focus:ring-sky-500"
+        >
+          每日練習
+        </button>
         <button
           onClick={onBack}
           className="px-8 py-3 bg-slate-600 text-white font-bold rounded-lg shadow-lg hover:bg-slate-700 transition-transform transform hover:scale-105 focus:outline-none focus:ring-4 focus:ring-slate-500"

--- a/constants.ts
+++ b/constants.ts
@@ -19,6 +19,19 @@ export const LEVELS: Level[] = [
   { title: "第十六課：挑戰長句", type: LevelType.Word, content: ["我喜歡用電腦學習新知識"], description: "挑戰完整的句子輸入。"},
 ];
 
+export function generateRandomLevel(): Level {
+  const wordPool = LEVELS.filter(l => l.type === LevelType.Word)
+    .flatMap(l => l.content as string[]);
+  const shuffled = [...wordPool].sort(() => Math.random() - 0.5);
+  const content = shuffled.slice(0, Math.min(3, shuffled.length));
+  return {
+    title: '每日練習',
+    type: LevelType.Random,
+    content,
+    description: '隨機練習常用詞彙。',
+  };
+}
+
 export const ZHUYIN_MAP: { [key: string]: string } = {
   // Original
   '你': 'ㄋㄧˇ', '好': 'ㄏㄠˇ', '台': 'ㄊㄞˊ', '灣': 'ㄨㄢ',

--- a/types.ts
+++ b/types.ts
@@ -10,12 +10,13 @@ export enum LevelType {
   SingleBopomofo, // Practice single zhuyin symbols like ㄅ, ㄆ, ㄇ, ㄈ
   Syllable,       // Practice combinations like ㄅㄚ, ㄆㄛˋ
   Word,           // Practice actual words like 你好, 台灣
+  Random,         // Randomly generated practice content
 }
 
 export interface Level {
   title: string;
   type: LevelType;
-  content: string | string[]; // string for SingleBopomofo, string[] for Syllable/Word
+  content: string | string[]; // string for SingleBopomofo, string[] for Syllable/Word/Random
   description?: string;
 }
 


### PR DESCRIPTION
## Summary
- add generator for daily random practice levels
- support LevelType.Random across app and gameplay
- expose "每日練習" button for quick random sessions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892511c9880832a995fcc63c77370bd