### PR TITLE
feat: add speech toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+dist/

--- a/App.tsx
+++ b/App.tsx
@@ -11,6 +11,14 @@ const App: React.FC = () => {
   const [gameState, setGameState] = useState<GameState>(GameState.Start);
   const [currentLevelIndex, setCurrentLevelIndex] = useState(0);
   const [score, setScore] = useState(0);
+  const [isSpeechEnabled, setIsSpeechEnabled] = useState(() => {
+    const stored = localStorage.getItem('isSpeechEnabled');
+    return stored === null ? true : stored === 'true';
+  });
+
+  useEffect(() => {
+    localStorage.setItem('isSpeechEnabled', String(isSpeechEnabled));
+  }, [isSpeechEnabled]);
 
   const goToLevelSelection = useCallback(() => {
     setGameState(GameState.LevelSelection);
@@ -63,7 +71,13 @@ const App: React.FC = () => {
   const renderContent = () => {
     switch (gameState) {
       case GameState.Start:
-        return <StartScreen onStart={goToLevelSelection} />;
+        return (
+          <StartScreen
+            onStart={goToLevelSelection}
+            isSpeechEnabled={isSpeechEnabled}
+            onToggleSpeech={() => setIsSpeechEnabled(prev => !prev)}
+          />
+        );
       case GameState.LevelSelection:
         return <LevelSelectionScreen onSelectLevel={selectLevelAndStart} onBack={goToStart} />;
       case GameState.Playing:
@@ -72,6 +86,8 @@ const App: React.FC = () => {
             level={LEVELS[currentLevelIndex]}
             levelNumber={currentLevelIndex + 1}
             onLevelComplete={handleLevelComplete}
+            isSpeechEnabled={isSpeechEnabled}
+            onToggleSpeech={() => setIsSpeechEnabled(prev => !prev)}
           />
         );
       case GameState.LevelComplete: {

--- a/components/GameScreen.tsx
+++ b/components/GameScreen.tsx
@@ -9,6 +9,8 @@ interface GameScreenProps {
   level: Level;
   levelNumber: number;
   onLevelComplete: (score: number) => void;
+  isSpeechEnabled: boolean;
+  onToggleSpeech: () => void;
 }
 
 type GamePhase = 'introduction' | 'practice';
@@ -20,7 +22,7 @@ const SpeakerIcon = () => (
 );
 
 
-const GameScreen: React.FC<GameScreenProps> = ({ level, levelNumber, onLevelComplete }) => {
+const GameScreen: React.FC<GameScreenProps> = ({ level, levelNumber, onLevelComplete, isSpeechEnabled, onToggleSpeech }) => {
   const [practiceUnits, setPracticeUnits] = useState<string[]>([]);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [userInputs, setUserInputs] = useState<string[]>([]);
@@ -39,7 +41,7 @@ const GameScreen: React.FC<GameScreenProps> = ({ level, levelNumber, onLevelComp
       units = (level.content as string).split('');
       setPhase('introduction');
       setIntroductionIndex(0);
-      speak(units[0]);
+      speak(units[0], isSpeechEnabled);
     } else if (level.type === LevelType.Syllable || level.type === LevelType.Word) {
       units = level.content as string[];
       setPhase('practice');
@@ -52,7 +54,7 @@ const GameScreen: React.FC<GameScreenProps> = ({ level, levelNumber, onLevelComp
     setIncorrectAttempts(0);
     setStartTime(Date.now());
     setActiveKey(null);
-  }, [level]);
+  }, [level, isSpeechEnabled]);
   
   useEffect(() => {
     if (phase === 'practice') {
@@ -82,7 +84,7 @@ const GameScreen: React.FC<GameScreenProps> = ({ level, levelNumber, onLevelComp
         if (introductionIndex < practiceUnits.length - 1) {
             const nextIndex = introductionIndex + 1;
             setIntroductionIndex(nextIndex);
-            speak(practiceUnits[nextIndex]);
+            speak(practiceUnits[nextIndex], isSpeechEnabled);
         } else {
             setPhase('practice');
             setStartTime(Date.now());
@@ -90,7 +92,7 @@ const GameScreen: React.FC<GameScreenProps> = ({ level, levelNumber, onLevelComp
     } else {
         handleIncorrect();
     }
-  }, [introductionIndex, practiceUnits, handleIncorrect]);
+  }, [introductionIndex, practiceUnits, handleIncorrect, isSpeechEnabled]);
 
 
   useEffect(() => {
@@ -162,6 +164,18 @@ const GameScreen: React.FC<GameScreenProps> = ({ level, levelNumber, onLevelComp
   return (
     <div className="flex flex-col h-full">
         <style>{`.animate-shake { animation: shake 0.5s; } @keyframes shake { 10%, 90% { transform: translate3d(-1px, 0, 0); } 20%, 80% { transform: translate3d(2px, 0, 0); } 30%, 50%, 70% { transform: translate3d(-4px, 0, 0); } 40%, 60% { transform: translate3d(4px, 0, 0); } }`}</style>
+      <div className="flex justify-end mb-4">
+        <label className="flex items-center gap-2 text-slate-300">
+          <input
+            type="checkbox"
+            checked={isSpeechEnabled}
+            onChange={() => onToggleSpeech()}
+            className="accent-sky-500"
+          />
+          語音
+        </label>
+      </div>
+
       <div className="flex justify-between items-center mb-6 p-4 bg-slate-800/50 rounded-lg">
         <div>
           <h2 className="text-2xl font-bold text-sky-300">{level.title}</h2>
@@ -181,7 +195,7 @@ const GameScreen: React.FC<GameScreenProps> = ({ level, levelNumber, onLevelComp
                 <p className="text-2xl text-slate-300 mb-4">教學模式：認識注音與鍵盤位置</p>
                 <div className="flex items-center gap-4 mb-4">
                     <div className="text-9xl font-bold p-8 rounded-2xl bg-slate-800/50">{currentIntroSymbol}</div>
-                    <button onClick={() => speak(currentIntroSymbol)} className="p-4 rounded-full bg-sky-500/50 hover:bg-sky-500 transition-colors">
+                    <button onClick={() => speak(currentIntroSymbol, isSpeechEnabled)} className="p-4 rounded-full bg-sky-500/50 hover:bg-sky-500 transition-colors">
                         <SpeakerIcon />
                     </button>
                 </div>

--- a/components/StartScreen.tsx
+++ b/components/StartScreen.tsx
@@ -3,22 +3,37 @@ import React from 'react';
 
 interface StartScreenProps {
   onStart: () => void;
+  isSpeechEnabled: boolean;
+  onToggleSpeech: () => void;
 }
 
-const StartScreen: React.FC<StartScreenProps> = ({ onStart }) => {
+const StartScreen: React.FC<StartScreenProps> = ({ onStart, isSpeechEnabled, onToggleSpeech }) => {
   return (
-    <div className="flex flex-col items-center justify-center h-full text-center">
-      <div className="mb-8">
-        <h2 className="text-5xl font-bold text-sky-300 mb-2">準備好挑戰了嗎？</h2>
-        <p className="text-xl text-slate-300">測試你的注音打字速度與準確度！</p>
+    <div className="flex flex-col h-full text-center">
+      <div className="flex justify-end">
+        <label className="flex items-center gap-2 text-slate-300">
+          <input
+            type="checkbox"
+            checked={isSpeechEnabled}
+            onChange={() => onToggleSpeech()}
+            className="accent-sky-500"
+          />
+          語音
+        </label>
       </div>
-      <button
-        onClick={onStart}
-        className="px-10 py-5 bg-indigo-600 text-white text-2xl font-bold rounded-xl shadow-lg hover:bg-indigo-700 transition-transform transform hover:scale-105 focus:outline-none focus:ring-4 focus:ring-indigo-400"
-      >
-        開始遊戲
-      </button>
-      <p className="mt-4 text-sm text-slate-400">按下 Enter 或 空白鍵 開始</p>
+      <div className="flex flex-col flex-grow items-center justify-center">
+        <div className="mb-8">
+          <h2 className="text-5xl font-bold text-sky-300 mb-2">準備好挑戰了嗎？</h2>
+          <p className="text-xl text-slate-300">測試你的注音打字速度與準確度！</p>
+        </div>
+        <button
+          onClick={onStart}
+          className="px-10 py-5 bg-indigo-600 text-white text-2xl font-bold rounded-xl shadow-lg hover:bg-indigo-700 transition-transform transform hover:scale-105 focus:outline-none focus:ring-4 focus:ring-indigo-400"
+        >
+          開始遊戲
+        </button>
+        <p className="mt-4 text-sm text-slate-400">按下 Enter 或 空白鍵 開始</p>
+      </div>
     </div>
   );
 };

--- a/utils/speech.ts
+++ b/utils/speech.ts
@@ -1,16 +1,17 @@
-export const speak = (text: string) => {
+export const speak = (text: string, enabled: boolean) => {
+  if (!enabled) return;
   if ('speechSynthesis' in window) {
     try {
       const utterance = new SpeechSynthesisUtterance(text);
       utterance.lang = 'zh-TW';
       utterance.rate = 0.8;
       utterance.pitch = 1;
-      
+
       // Cancel any previous speech to prevent overlap
       window.speechSynthesis.cancel();
       window.speechSynthesis.speak(utterance);
     } catch (error) {
-        console.error("Speech synthesis error:", error);
+      console.error('Speech synthesis error:', error);
     }
   } else {
     console.error('Speech synthesis not supported in this browser.');


### PR DESCRIPTION
## Summary
- persist speech preference in localStorage
- add speech toggle in start and game screens
- gate speech synthesis with preference

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892512999fc832a8282dfaef9306e9f